### PR TITLE
Qwen 3.5 fixes

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -981,6 +981,7 @@ class Scheduler(
         if (
             self.server_args.language_only
             and self.server_args.encoder_transfer_backend == "zmq_to_scheduler"
+            and self.server_args.encoder_urls
         ):
             self.mm_receiver = create_mm_receiver(
                 self.server_args,
@@ -1312,6 +1313,7 @@ class Scheduler(
             self.pp_rank == 0
             and self.server_args.language_only
             and self.server_args.encoder_transfer_backend == "zmq_to_scheduler"
+            and hasattr(self, "mm_receiver")
         ):
             recv_reqs, abort_reqs = self.mm_receiver.process_waiting_requests(recv_reqs)
             for req, error_msg, error_code in abort_reqs:

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -408,7 +408,7 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
         self.bootstrap_server = start_disagg_service(self.server_args)
 
         # Encoder Disaggregation
-        if self.server_args.language_only:
+        if self.server_args.language_only and self.server_args.encoder_urls:
             self.mm_receiver = create_mm_receiver(
                 self.server_args,
                 dtype=self.model_config.dtype,
@@ -496,7 +496,7 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
                 )
 
         self._req_stats_init(obj, request)
-        if self.server_args.language_only:
+        if self.server_args.language_only and hasattr(self, "mm_receiver"):
             self._handle_epd_disaggregation_encode_request(obj)
         if self.server_args.tokenizer_worker_num > 1:
             self._attach_multi_http_worker_info(obj)
@@ -717,6 +717,11 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
                 in ["zmq_to_tokenizer", "mooncake"]
             ):
                 if self.server_args.language_only:
+                    if not hasattr(self, "mm_receiver"):
+                        raise ValueError(
+                            "language_only without --encoder-urls cannot accept "
+                            "image, video, or audio inputs"
+                        )
                     mm_inputs = await self.mm_receiver.recv_mm_data(
                         img_data=obj.image_data,
                         mm_processor=self.mm_processor,

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -665,6 +665,7 @@ class Qwen3_5ForCausalLM(nn.Module):
         config: Qwen3_5TextConfig,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        embed_tokens_module: Optional[nn.Module] = None,
     ) -> None:
         super().__init__()
         self.config = config
@@ -675,12 +676,15 @@ class Qwen3_5ForCausalLM(nn.Module):
 
         # Embedding layer
         if self.pp_group.is_first_rank:
-            self.embed_tokens = VocabParallelEmbedding(
-                config.vocab_size,
-                config.hidden_size,
-                org_num_embeddings=config.vocab_size,
-                enable_tp=not is_dp_attention_enabled(),
-            )
+            if embed_tokens_module is not None:
+                self.embed_tokens = embed_tokens_module
+            else:
+                self.embed_tokens = VocabParallelEmbedding(
+                    config.vocab_size,
+                    config.hidden_size,
+                    org_num_embeddings=config.vocab_size,
+                    enable_tp=not is_dp_attention_enabled(),
+                )
         else:
             self.embed_tokens = PPMissingLayer()
 

--- a/python/sglang/srt/models/qwen3_5_mtp.py
+++ b/python/sglang/srt/models/qwen3_5_mtp.py
@@ -22,16 +22,47 @@ from torch import nn
 from transformers import PretrainedConfig
 
 from sglang.srt.distributed import get_pp_group, get_tensor_model_parallel_world_size
+from sglang.srt.layers.dp_attention import is_dp_attention_enabled
 from sglang.srt.layers.layernorm import GemmaRMSNorm
 from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
-from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
+from sglang.srt.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.qwen3_5 import Qwen3_5ForCausalLM
 from sglang.srt.utils import add_prefix
 
 logger = logging.getLogger(__name__)
+
+
+class DeferredSharedEmbedding(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self._shared_module = None
+        self.weight = None
+
+    def attach_module(self, module: nn.Module) -> None:
+        self._shared_module = module
+        self.weight = module.weight
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        if self._shared_module is None:
+            raise RuntimeError(
+                "Qwen3.5 MTP draft embedding has not been attached to the target model."
+            )
+        return self._shared_module(input_ids)
+
+
+class DeferredSharedLMHead(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = None
+
+    def attach_module(self, module: nn.Module) -> None:
+        self.weight = module.weight
 
 
 class Qwen3_5ForCausalLMMTP(nn.Module):
@@ -56,6 +87,9 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
         self.tp_size = get_tensor_model_parallel_world_size()
         self.quant_config = quant_config
         self.pp_group = get_pp_group()
+        embed_tokens_module = (
+            DeferredSharedEmbedding() if self.pp_group.is_first_rank else None
+        )
 
         self.fc = nn.Linear(2 * config.hidden_size, config.hidden_size, bias=False)
         RMSNorm_cls = GemmaRMSNorm
@@ -69,18 +103,14 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
             config,
             quant_config,
             prefix=add_prefix("mtp", prefix),
+            embed_tokens_module=embed_tokens_module,
         )
 
         if get_pp_group().is_last_rank:
             if config.tie_word_embeddings:
                 self.lm_head = self.model.embed_tokens
             else:
-                self.lm_head = ParallelLMHead(
-                    config.vocab_size,
-                    config.hidden_size,
-                    quant_config=quant_config,
-                    prefix=add_prefix("lm_head", prefix),
-                )
+                self.lm_head = DeferredSharedLMHead()
 
         self.logits_processor = LogitsProcessor(config)
 
@@ -88,14 +118,50 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
         return self.model.embed_tokens.weight, self.lm_head.weight
 
     def set_embed_and_head(self, embed, head):
+        self._materialize_embed_tokens()
         del self.model.embed_tokens.weight
-        if not self.config.tie_word_embeddings:
-            del self.lm_head.weight
-
         self.model.embed_tokens.weight = embed
-        self.lm_head.weight = head
+
+        if not self.config.tie_word_embeddings:
+            self._materialize_lm_head()
+            del self.lm_head.weight
+            self.lm_head.weight = head
         torch.cuda.empty_cache()
         torch.cuda.synchronize()
+
+    def set_embed_and_head_modules(self, embed_tokens: nn.Module, lm_head: nn.Module):
+        if isinstance(self.model.embed_tokens, DeferredSharedEmbedding):
+            self.model.embed_tokens.attach_module(embed_tokens)
+        else:
+            self.model.embed_tokens = embed_tokens
+
+        if get_pp_group().is_last_rank:
+            if self.config.tie_word_embeddings:
+                self.lm_head = self.model.embed_tokens
+            elif isinstance(self.lm_head, DeferredSharedLMHead):
+                self.lm_head.attach_module(lm_head)
+            else:
+                self.lm_head = lm_head
+
+    def _materialize_embed_tokens(self) -> None:
+        if not isinstance(self.model.embed_tokens, DeferredSharedEmbedding):
+            return
+        embed_tokens = VocabParallelEmbedding(
+            self.config.vocab_size,
+            self.config.hidden_size,
+            org_num_embeddings=self.config.vocab_size,
+            enable_tp=not is_dp_attention_enabled(),
+        )
+        self.model.embed_tokens = embed_tokens
+
+    def _materialize_lm_head(self) -> None:
+        if not isinstance(self.lm_head, DeferredSharedLMHead):
+            return
+        self.lm_head = ParallelLMHead(
+            self.config.vocab_size,
+            self.config.hidden_size,
+            quant_config=self.quant_config,
+        )
 
     @torch.no_grad()
     def forward(

--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -1026,28 +1026,33 @@ class Qwen3VLForConditionalGeneration(nn.Module):
         super().__init__()
         self.pp_group = get_pp_group()
         self.quant_config = quant_config
+        encoder_only = getattr(config, "encoder_only", False)
+        language_only = getattr(config, "language_only", False)
 
         self.use_data_parallel = get_global_server_args().mm_enable_dp_encoder
 
-        self.visual = Qwen3VLMoeVisionModel(
-            config.vision_config,
-            # NOTE: Qwen3-VL vision encoder currently supports BitsAndBytes 4-bit quantization.
-            # Other quantization methods (e.g., GPTQ, AWQ) are untested and may not be supported.
-            quant_config=None,
-            norm_eps=getattr(config, "rms_norm_eps", 1e-6),
-            prefix=add_prefix("model.visual", prefix),
-            use_data_parallel=self.use_data_parallel,
-        )
+        if language_only:
+            self.visual = None
+        else:
+            self.visual = Qwen3VLMoeVisionModel(
+                config.vision_config,
+                # NOTE: Qwen3-VL vision encoder currently supports BitsAndBytes 4-bit quantization.
+                # Other quantization methods (e.g., GPTQ, AWQ) are untested and may not be supported.
+                quant_config=None,
+                norm_eps=getattr(config, "rms_norm_eps", 1e-6),
+                prefix=add_prefix("model.visual", prefix),
+                use_data_parallel=self.use_data_parallel,
+            )
 
         # TODO: make it more elegant
         if language_model_cls is Qwen3LLMModel:
             self.config: Qwen3VLConfig = config  # for qwen3-vl
         else:
             self.config = config.text_config  # for qwen3-omni
-            self.config.encoder_only = getattr(config, "encoder_only", False)
-            self.config.language_only = getattr(config, "language_only", False)
+        self.config.encoder_only = encoder_only
+        self.config.language_only = language_only
 
-        if not hasattr(config, "encoder_only") or not config.encoder_only:
+        if not encoder_only:
             self.model = language_model_cls(
                 config=self.config,
                 quant_config=quant_config,
@@ -1078,9 +1083,22 @@ class Qwen3VLForConditionalGeneration(nn.Module):
         # 8, 16, 24 layer will be merged to 0, 1, 2 layer of decoder output hidden_states
 
         # deepstack
-        self.deepstack_visual_indexes = config.vision_config.deepstack_visual_indexes
+        self.deepstack_visual_indexes = (
+            [] if language_only else config.vision_config.deepstack_visual_indexes
+        )
         self.num_deepstack_embeddings = len(self.deepstack_visual_indexes)
-        self.use_deepstack = {Modality.IMAGE: True, Modality.VIDEO: True}
+        self.use_deepstack = {
+            Modality.IMAGE: not language_only,
+            Modality.VIDEO: not language_only,
+        }
+
+    def _require_visual(self):
+        if self.visual is None:
+            raise RuntimeError(
+                "This model was initialized with language_only=True and cannot "
+                "process image or video inputs."
+            )
+        return self.visual
 
     def separate_deepstack_embeds(self, embedding):
         assert (
@@ -1097,9 +1115,10 @@ class Qwen3VLForConditionalGeneration(nn.Module):
         return pattern.pad_input_tokens(input_ids, mm_inputs)
 
     def get_image_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
+        visual = self._require_visual()
         # in qwen-vl, last dim is the same
         pixel_values = torch.cat([item.feature for item in items], dim=0).type(
-            self.visual.dtype
+            visual.dtype
         )
         image_grid_thw = torch.concat([item.image_grid_thw for item in items], dim=0)
         assert pixel_values.dim() == 2, pixel_values.dim()
@@ -1111,13 +1130,13 @@ class Qwen3VLForConditionalGeneration(nn.Module):
         if max_patches_per_call == 0 and max_images_per_call == 0:
             if self.use_data_parallel:
                 return run_dp_sharded_mrope_vision_model(
-                    self.visual,
+                    visual,
                     pixel_values,
                     image_grid_thw.tolist(),
                     rope_type="rope_3d",
                 )
             else:
-                return self.visual(pixel_values, grid_thw=image_grid_thw)
+                return visual(pixel_values, grid_thw=image_grid_thw)
 
         # compute the number of patches per image and the slice positions in pixel_values
         grid_thw_list = (
@@ -1183,13 +1202,13 @@ class Qwen3VLForConditionalGeneration(nn.Module):
             # run ViT once on this chunk without extra padding
             if self.use_data_parallel:
                 chunk_embeds = run_dp_sharded_mrope_vision_model(
-                    self.visual,
+                    visual,
                     pixel_chunk,
                     grid_chunk.tolist(),
                     rope_type="rope_3d",
                 )
             else:
-                chunk_embeds = self.visual(pixel_chunk, grid_thw=grid_chunk)
+                chunk_embeds = visual(pixel_chunk, grid_thw=grid_chunk)
 
             # chunk_embeds: (sum_patches_after_merge_this_chunk, hidden)
             all_chunk_embeds.append(chunk_embeds)
@@ -1201,11 +1220,12 @@ class Qwen3VLForConditionalGeneration(nn.Module):
         return torch.cat(all_chunk_embeds, dim=0)
 
     def get_video_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
+        visual = self._require_visual()
         for item in items:
-            item.feature = item.feature.to(self.visual.device)
+            item.feature = item.feature.to(visual.device)
         # in qwen-vl, last dim is the same
         pixel_values = torch.cat([item.feature for item in items], dim=0).type(
-            self.visual.dtype
+            visual.dtype
         )
         # Memory optimization for item.feature:
         # 1. item.feature is released when request finished
@@ -1218,10 +1238,10 @@ class Qwen3VLForConditionalGeneration(nn.Module):
         assert video_grid_thw.dim() == 2, video_grid_thw.dim()
         if self.use_data_parallel:
             return run_dp_sharded_mrope_vision_model(
-                self.visual, pixel_values, video_grid_thw.tolist(), rope_type="rope_3d"
+                visual, pixel_values, video_grid_thw.tolist(), rope_type="rope_3d"
             )
         else:
-            video_embeds = self.visual(pixel_values, grid_thw=video_grid_thw)
+            video_embeds = visual(pixel_values, grid_thw=video_grid_thw)
         return video_embeds
 
     def get_input_embeddings(self):

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -228,7 +228,7 @@ class SchedulerMetricsMixin:
         else:
             msg += f"input throughput (token/s): {self.last_input_throughput:.2f}, "
 
-        if self.server_args.language_only:
+        if self.server_args.language_only and hasattr(self, "mm_receiver"):
             msg += f"waiting-image-req: {len(self.mm_receiver.waiting_list)}, "
         graph_backend = defaultdict(
             lambda: "cuda graph",
@@ -398,7 +398,7 @@ class SchedulerMetricsMixin:
             msg += f"#transfer-req: {len(self.disagg_decode_transfer_queue.queue)}, "
             msg += f"#retracted-req: {len(self.disagg_decode_prealloc_queue.retracted_queue)}, "
 
-        if self.server_args.language_only:
+        if self.server_args.language_only and hasattr(self, "mm_receiver"):
             msg += f"waiting-image-req: {len(self.mm_receiver.waiting_list)}, "
 
         graph_backend = defaultdict(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2736,11 +2736,6 @@ class ServerArgs:
                 "Cannot set --encoder-only and --disaggregation-mode prefill/decode together"
             )
 
-        if self.language_only and len(self.encoder_urls) == 0:
-            raise ValueError(
-                "requires at least one encoder urls to be set via --encoder-urls"
-            )
-
         # Validate IB devices when mooncake backend is used
         if (
             self.disaggregation_transfer_backend == "mooncake"

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -154,7 +154,8 @@ class EAGLEWorker(TpModelWorker):
                 token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
             )
 
-        embed, head = self.target_worker.model_runner.model.get_embed_and_head()
+        target_model = self.target_worker.model_runner.model
+        embed, head = target_model.get_embed_and_head()
 
         if self.speculative_algorithm.is_eagle3():
             # most cases EAGLE3 models don't share lm_head
@@ -180,7 +181,16 @@ class EAGLEWorker(TpModelWorker):
                 head.data = head.data[self.hot_token_id]
 
             # Share the embedding and lm_head
-            self.draft_model_runner.model.set_embed_and_head(embed, head)
+            if (
+                self.hot_token_id is None
+                and hasattr(self.draft_model_runner.model, "set_embed_and_head_modules")
+            ):
+                self.draft_model_runner.model.set_embed_and_head_modules(
+                    target_model.model.embed_tokens,
+                    target_model.lm_head,
+                )
+            else:
+                self.draft_model_runner.model.set_embed_and_head(embed, head)
 
         # Init attention backend and cuda graphs
         self.draft_model_runner.server_args.disable_cuda_graph = (

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -191,7 +191,8 @@ class EagleDraftWorker(BaseDraftWorker):
             self.hot_token_id = None
 
     def init_lm_head(self):
-        embed, head = self.target_worker.model_runner.model.get_embed_and_head()
+        target_model = self.target_worker.model_runner.model
+        embed, head = target_model.get_embed_and_head()
         if self.speculative_algorithm.is_eagle3():
             # most cases EAGLE3 models don't share lm_head
             # but some models (e.g. nvidia/gpt-oss-120b-Eagle3) shares
@@ -216,7 +217,16 @@ class EagleDraftWorker(BaseDraftWorker):
                 head.data = head.data[self.hot_token_id]
 
             # Share the embedding and lm_head
-            self.draft_runner.model.set_embed_and_head(embed, head)
+            if (
+                self.hot_token_id is None
+                and hasattr(self.draft_runner.model, "set_embed_and_head_modules")
+            ):
+                self.draft_runner.model.set_embed_and_head_modules(
+                    target_model.model.embed_tokens,
+                    target_model.lm_head,
+                )
+            else:
+                self.draft_runner.model.set_embed_and_head(embed, head)
 
     def init_attention_backend(self):
         # Create multi-step attn backends and cuda graph runners


### PR DESCRIPTION
## Summary

This PR fixes Qwen3.5 serving in three areas:

- Enables real pipeline parallelism for the Qwen3.5 decoder instead of having each PP rank keep the full decoder.
- Makes `--language-only` work for Qwen3.5 without requiring external encoder URLs, and skips constructing the vision tower entirely in that mode.
- Reduces Qwen3.5 MTP startup memory by removing the transient duplicate draft embedding / `lm_head` allocation during speculative draft worker init.

## Changes

- `python/sglang/srt/models/qwen3_5.py`
  - Partition decoder layers by PP rank via `make_layers(..., pp_rank, pp_size)`.
  - Run only local `start_layer:end_layer` in forward.
  - Skip loading non-local layer weights.
  - Allow injecting a pre-shared embedding module for MTP draft init.

- `python/sglang/srt/models/qwen3_vl.py`
  - In `language_only` mode, do not instantiate the vision encoder.
  - Disable deepstack visual handling in `language_only`.
  - Fail fast if image/video features are requested while `language_only=True`.

- `python/sglang/srt/server_args.py`
  - Remove the validation that forced `--language-only` to also specify `--encoder-urls`.

- `python/sglang/srt/managers/tokenizer_manager.py`
- `python/sglang/srt/managers/scheduler.py`
- `python/sglang/srt/observability/scheduler_metrics_mixin.py`
  - Allow local text-only `language_only` operation without external encoder services.
  - Only initialize multimodal disaggregation receivers when encoder URLs are configured.
  - Return a clear error if multimodal inputs are sent to local `language_only` serving without an external encoder.

- `python/sglang/srt/models/qwen3_5_mtp.py`
- `python/sglang/srt/speculative/eagle_worker.py`
- `python/sglang/srt/speculative/eagle_worker_v2.py`
  - Replace eager draft embed/head allocation with deferred shared placeholders.
  - Attach the target model’s embed/head modules directly for Qwen3.5 MTP draft workers.
  - Reduce peak init RAM during `NEXTN` / EAGLE startup.

## User-facing impact

- Qwen3.5 PP now actually shards decoder memory.
- `--language-only` can be used locally for Qwen3.5 without `--encoder-urls`.
- Qwen3.5 `NEXTN` no longer OOMs at draft embedding allocation due to a transient duplicate embedding table.
- If multimodal inputs are sent to local `language_only` serving without external encoders, the failure is explicit.

## Testing

```bash
python3 -m py_compile \
  python/sglang/srt/models/qwen3_5.py \
  python/sglang/srt/models/qwen3_5_mtp.py \
  python/sglang/srt/models/qwen3_vl.py \
  python/sglang/srt/server_args.py \
  python/sglang/srt/managers/tokenizer_manager.py \
  python/sglang/srt/managers/scheduler.py \
  python/sglang/srt/observability/scheduler_metrics_mixin.py \
  python/sglang/srt/speculative/eagle_worker.py \
  python/sglang/srt/speculative/eagle_worker_v2.py
```

Full runtime boot was not completed in this environment. After the MTP RAM fix, the remaining observed failure mode was KV-pool sizing, not duplicate draft embedding allocation.

## Notes

For Qwen3.5 speculative decoding on smaller GPUs, the remaining practical limit is now KV/cache and speculative graph reservation, rather than transient draft embedding duplication during initialization.